### PR TITLE
Add ability to add an access_token as a Authorization header to the request

### DIFF
--- a/webtask.json
+++ b/webtask.json
@@ -30,6 +30,15 @@
     "WEBHOOK_CONCURRENT_CALLS":     {
       "description": "The maximum concurrent calls that will be made to your webhook",
       "default": 5
+    },
+    "WEBHOOK_AUTH_CLIENT_ID": {
+      "description": "The client id for generating an access token to call the WEBHOOK_URL"
+    },
+    "WEBHOOK_AUTH_CLIENT_SECRET": {
+      "description": "The client secret for generating an access token to call the WEBHOOK_URL"
+    },
+    "WEBHOOK_AUTH_RESOURCE_SERVER": {
+      "description": "The resource server issuing the access token to call the WEBHOOK_URL"
     }
   }
 }


### PR DESCRIPTION
#2 

This allows you to add an access_token as an authorization header to the request by specifying a client_id, client_secret, and resource_server. It assumes that the token issuer is the Auth0 domain in the context.

I know this is a little specific, so I'm happy to hear/implement some feedback on how it could be made more flexible/support different auth methods.  