### PR TITLE
Removed word 'logs' from placeholder as the logs endpoints are readonly

### DIFF
--- a/webtask.json
+++ b/webtask.json
@@ -27,7 +27,7 @@
     },
     "AUTH0_API_ENDPOINTS": {
       "description": "Allows you to filter specific API endpoints, comma separated.",
-      "example": "e.g.: users, connections, rules, logs, emails, stats, clients, tenants"
+      "example": "e.g.: users, connections, rules, emails, stats, clients, tenants"
     },
     "WEBHOOK_URL":     {
       "required": true,


### PR DESCRIPTION
## ✏️ Changes
  
The current `/api/v2/logs` endpoints are readonly, so there are no log messages about logs. Having listed "logs" in the filters description is confusing, as there are no such log events to trigger the webhooks when only `logs` is specified as value.

## 🎯 Testing
  
Nothing to test here really, as it is a cosmetic change.

🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🎡 Rollout
  
To test this change it is necessary to open the installation dialog for the extension and check that the value for `AUTH0_API_ENDPOINTS` does NOT contain the word "logs".

## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
